### PR TITLE
Remove -p compilation option

### DIFF
--- a/semantic_versioning.gpr
+++ b/semantic_versioning.gpr
@@ -17,7 +17,7 @@ project Semantic_Versioning is
    end Builder;
 
    package Compiler is
-      for Switches ("ada") use ("-gnatVa", "-gnatwa", "-g", "-p", "-O2", "-gnat12",
+      for Switches ("ada") use ("-gnatVa", "-gnatwa", "-g", "-O2", "-gnat12",
                                 "-gnato", "-fstack-check", "-gnata");
    end Compiler;
 


### PR DESCRIPTION
On Windows this profiling option produce a link error:
undefined reference to `__fentry__'

If someone wants to do profiling on this library, the option can still be
passed on gprbuild command line.