### PR TITLE
Simplify extended sets removing repeated subtrees

### DIFF
--- a/src/semantic_versioning-demo.adb
+++ b/src/semantic_versioning-demo.adb
@@ -132,6 +132,19 @@ begin
    pragma Assert (X.Value ("*").Image = X.Any.Image);
    pragma Assert (X.Value ("*").Image = X.Value ("any").Image);
 
+   --  Simplifications within extended expressions
+   pragma Assert (X.Value ("1") = (X.Value ("1") and X.Value ("1")));
+   pragma Assert (X.Value ("*") = (X.Value ("*") or X.Value ("1.0")));
+   pragma Assert (X.Value ("1.0") = (X.Value ("*") and X.Value ("1.0")));
+   pragma Assert ((X.Value ("1") and
+                    (X.Value ("2") and X.Value ("1"))) =
+                  (X.Value ("2") and X.Value ("1")));
+   pragma Assert ((X.Value ("1") or
+                    (X.Value ("2") or
+                         (X.Value ("3") or X.Value ("1")))) =
+                  (X.Value ("2") or
+                    (X.Value ("3") or X.Value ("1"))));
+
    --  X + Unicode
    pragma Assert (X.Is_In (V ("1.1"), X.Value ("≠1")));
    pragma Assert (X.Is_In (V ("1.1"), X.Value ("≥1")));

--- a/src/semantic_versioning-extended.ads
+++ b/src/semantic_versioning-extended.ads
@@ -22,10 +22,15 @@ package Semantic_Versioning.Extended with Preelaborate is
    end record;
 
    function "and" (L, R : Version_Set) return Version_Set;
-   --  Creates a new tree that is (L) & (R).
+   --  Creates a new tree that is Simplify ((L) & (R)).
 
    function "or" (L, R : Version_Set) return Version_Set;
-   --  Creates a new tree that is (L) | (R).
+   --  Creates a new tree that is Simplify ((L) | (R)).
+
+   function Simplify (VS : Version_Set) return Version_Set;
+   --  Apply trivial and/or simplifications to the set: "* & =1.0" --> "=1.0",
+   --  "* | =1.0" --> "*", "=1.0 & =1.0" --> "=1.0"... Won't be clever enough
+   --  to simplify "^1.0 & ^1.1" --> "^1.1" and similar.
 
    function Is_In (V : Version; VS : Version_Set) return Boolean;
 


### PR DESCRIPTION
When combining dependencies, apply some trivial simplifications and detect repeated subtrees that can be omitted.