### PR TITLE
Removed non-mandated check for '-' in pre-release part

### DIFF
--- a/src/semantic_versioning.adb
+++ b/src/semantic_versioning.adb
@@ -117,14 +117,6 @@ package body Semantic_Versioning is
             Last := Last + 1;
          end loop;
 
-         if not Relaxed then
-            for C of Description (Next .. Last - 1) loop
-               if C = '-' then
-                  raise Malformed_Input with "Second '-' found inside pre-release part: " & Description;
-               end if;
-            end loop;
-         end if;
-
          V.Pre_Release := UStrings.To_Unbounded_String (Description (Next .. Last - 1));
          Next := Last;
 


### PR DESCRIPTION
Actually the spec allows only alphanumeric | '-' in the pre-release part. This is not currently enforced (anything goes even in not relaxed mode).

It's starting to seem that a simple implementation based on regexes might be less painful to maintain and more compliant.